### PR TITLE
When Ctrl+C pressed in the terminal, Docker container is stopped.

### DIFF
--- a/src/main/resources/docker-entrypoint.sh
+++ b/src/main/resources/docker-entrypoint.sh
@@ -14,4 +14,4 @@ on_exit () {
 }
 trap on_exit EXIT
 
-env|sort && "$@"
+env|sort && "$@" & wait


### PR DESCRIPTION
Runs start-domain in backround and waits, so that the Ctrl+C signal is handled immediately. If it's started in foreground, the signal is triggered after the command stops, so never.

This still keeps the same behavior when `docker stop` is executed - the trap is triggered immediately as before.