### PR TITLE
Clear autodeploystatus so that applications are always deployed.

### DIFF
--- a/src/main/resources/docker-entrypoint.sh
+++ b/src/main/resources/docker-entrypoint.sh
@@ -14,4 +14,6 @@ on_exit () {
 }
 trap on_exit EXIT
 
+rm -rf glassfish/domains/domain1/autodeploy/.autodeploystatus || true
+
 env|sort && "$@" & wait

--- a/src/main/resources/docker-entrypoint.sh
+++ b/src/main/resources/docker-entrypoint.sh
@@ -14,6 +14,11 @@ on_exit () {
 }
 trap on_exit EXIT
 
-rm -rf glassfish/domains/domain1/autodeploy/.autodeploystatus || true
+CONTAINER_ALREADY_STARTED="CONTAINER_ALREADY_STARTED_PLACEHOLDER"
+if [ ! -f "$CONTAINER_ALREADY_STARTED" ]
+then
+    touch "$CONTAINER_ALREADY_STARTED" &&
+    rm -rf glassfish/domains/domain1/autodeploy/.autodeploystatus || true
+fi
 
 env|sort && "$@" & wait


### PR DESCRIPTION
Without this, if the same mounted directory is used for multiple container executions, the second execution will think that the apps were already deployed and won't deploy them. 