### PR TITLE
Multi-architecture support

### DIFF
--- a/7.0.0/Dockerfile
+++ b/7.0.0/Dockerfile
@@ -47,14 +47,16 @@ RUN true \
     && unset AS_ADMIN_PASSWORD \
     && set -x \
     && env | sort \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} change-admin-password \
     && asadmin stop-domain --kill \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=false \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.SimpleLogHandler.level=FINEST \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} enable-secure-admin \
-    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain \
+    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain --kill \
     && rm -f ${PATH_GF_SERVER_LOG} ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} \
     && chown -R glassfish:glassfish "${PATH_GF_HOME}" \
     && chmod +x /usr/local/bin/docker-entrypoint.sh \

--- a/7.0.0/dockerlibfile-fragment.txt
+++ b/7.0.0/dockerlibfile-fragment.txt
@@ -1,3 +1,3 @@
 Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: linux/amd64,linux/arm64
 Directory: 7.0.0

--- a/7.0.1/Dockerfile
+++ b/7.0.1/Dockerfile
@@ -47,14 +47,16 @@ RUN true \
     && unset AS_ADMIN_PASSWORD \
     && set -x \
     && env | sort \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} change-admin-password \
     && asadmin stop-domain --kill \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=false \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.SimpleLogHandler.level=FINEST \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} enable-secure-admin \
-    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain \
+    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain --kill \
     && rm -f ${PATH_GF_SERVER_LOG} ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} \
     && chown -R glassfish:glassfish "${PATH_GF_HOME}" \
     && chmod +x /usr/local/bin/docker-entrypoint.sh \

--- a/7.0.1/dockerlibfile-fragment.txt
+++ b/7.0.1/dockerlibfile-fragment.txt
@@ -1,3 +1,3 @@
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: linux/amd64,linux/arm64
 Directory: 7.0.1

--- a/7.0.2/Dockerfile
+++ b/7.0.2/Dockerfile
@@ -47,14 +47,16 @@ RUN true \
     && unset AS_ADMIN_PASSWORD \
     && set -x \
     && env | sort \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} change-admin-password \
     && asadmin stop-domain --kill \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=false \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.SimpleLogHandler.level=FINEST \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} enable-secure-admin \
-    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain \
+    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain --kill \
     && rm -f ${PATH_GF_SERVER_LOG} ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} \
     && chown -R glassfish:glassfish "${PATH_GF_HOME}" \
     && chmod +x /usr/local/bin/docker-entrypoint.sh \

--- a/7.0.2/dockerlibfile-fragment.txt
+++ b/7.0.2/dockerlibfile-fragment.txt
@@ -1,3 +1,3 @@
 Tags: 7.0.2, 7.0.2-jdk17, 7.0.2-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: linux/amd64,linux/arm64
 Directory: 7.0.2

--- a/7.0.3/Dockerfile
+++ b/7.0.3/Dockerfile
@@ -47,14 +47,16 @@ RUN true \
     && unset AS_ADMIN_PASSWORD \
     && set -x \
     && env | sort \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} change-admin-password \
     && asadmin stop-domain --kill \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=false \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.SimpleLogHandler.level=FINEST \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} enable-secure-admin \
-    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain \
+    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain --kill \
     && rm -f ${PATH_GF_SERVER_LOG} ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} \
     && chown -R glassfish:glassfish "${PATH_GF_HOME}" \
     && chmod +x /usr/local/bin/docker-entrypoint.sh \

--- a/7.0.3/dockerlibfile-fragment.txt
+++ b/7.0.3/dockerlibfile-fragment.txt
@@ -1,3 +1,3 @@
 Tags: 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: linux/amd64,linux/arm64
 Directory: 7.0.3

--- a/7.0.4/Dockerfile
+++ b/7.0.4/Dockerfile
@@ -47,14 +47,16 @@ RUN true \
     && unset AS_ADMIN_PASSWORD \
     && set -x \
     && env | sort \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} change-admin-password \
     && asadmin stop-domain --kill \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=false \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.SimpleLogHandler.level=FINEST \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} enable-secure-admin \
-    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain \
+    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain --kill \
     && rm -f ${PATH_GF_SERVER_LOG} ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} \
     && chown -R glassfish:glassfish "${PATH_GF_HOME}" \
     && chmod +x /usr/local/bin/docker-entrypoint.sh \

--- a/7.0.4/dockerlibfile-fragment.txt
+++ b/7.0.4/dockerlibfile-fragment.txt
@@ -1,3 +1,3 @@
 Tags: 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: linux/amd64,linux/arm64
 Directory: 7.0.4

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <docker.glassfish.repository>glassfish</docker.glassfish.repository>
         <docker.glassfish.tag>${glassfish.version}</docker.glassfish.tag>
         <docker.glassfish.image>${docker.glassfish.repository}:${docker.glassfish.tag}</docker.glassfish.image>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
     </properties>
 
     <build>
@@ -149,6 +150,11 @@
                         <image>
                             <name>${docker.glassfish.repository}</name>
                             <build>
+                                <buildx>
+                                    <platforms>
+                                        <platform>${docker.platforms}</platform>
+                                    </platforms>
+                                </buildx>
                                 <tags>
                                     <tag>${docker.glassfish.tag}</tag>
                                 </tags>

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -47,14 +47,16 @@ RUN true \
     && unset AS_ADMIN_PASSWORD \
     && set -x \
     && env | sort \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} change-admin-password \
     && asadmin stop-domain --kill \
-    && asadmin start-domain \
+    && AS_START_TIMEOUT=120000 asadmin start-domain \
+    && curl  -o /dev/null http://localhost:4848 \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=false \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} set-log-attributes org.glassfish.main.jul.handler.SimpleLogHandler.level=FINEST \
     && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} enable-secure-admin \
-    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain \
+    && asadmin --user ${AS_USER} --passwordfile ${AS_PASSWORD_FILE} stop-domain --kill \
     && rm -f ${PATH_GF_SERVER_LOG} ${PATH_GF_PASSWORD_FILE_FOR_CHANGE} \
     && chown -R glassfish:glassfish "${PATH_GF_HOME}" \
     && chmod +x /usr/local/bin/docker-entrypoint.sh \

--- a/src/main/resources/dockerlibfile-fragment.txt
+++ b/src/main/resources/dockerlibfile-fragment.txt
@@ -1,3 +1,3 @@
 Tags: @glassfish.version@, @glassfish.version@-jdk17, @glassfish.version@-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: @docker.platforms@
 Directory: @glassfish.version@


### PR DESCRIPTION
Docker images can support multiple platforms, which means that a single image may contain variants for different architectures, and sometimes for different operating systems. When running an image with multi-platform support, `docker` automatically selects the image that matches your OS and architecture.Most of the Docker Official Images on Docker Hub provide a [variety of architectures](https://github.com/docker-library/official-images#architectures-other-than-amd64). 

[Docker Buildx](https://github.com/docker/buildx) is a Docker CLI plugin that supports the construction of multi-architecture images. By using Buildx, you can build images for different CPU architectures at the same time in one command without using different Dockerfiles.

According to the [documentation](https://dmp.fabric8.io/#build-buildx), `docker-maven-plugin` also uses `buildx` to support building multi-architecture images, simply by defining the `<buildx>` element in the `<build>`

```xml
<configuration>
  <images>
    <image>
      <name>${project.groupId}.${project.artifactId}</name>
      <build>
        <buildx>
          <platforms>
            <platform>${docker.platforms}</platform>
          </platforms>
        </buildx>
        <!-- add other configuration ... -->
      </build>
    </image>
  </images>
</configuration>
```

The documentation says that although we define multiple platforms using `<platform></platform>`, e.g. `<platform>linux/amd64,linux/arm64</platform>`, because Docker's local image cache cannot hold multi-architecture images, so using `mvn clean install` will only build images for the local platform.

During deploy phase,  using `mvn clean deploy docker:push`,  the build machine will build and push all images to the registry. Any downstream consumers, regardless of native architecture, will be able to use the multi-architecture image.

GlassFish's Dockerfile depends on the base image [eclipse-temurin:17.0.7_7-jdk](https://hub.docker.com/layers/library/eclipse-temurin/17.0.7_7-jdk/images/sha256-da794e3718439e4acb1798655a6341f42bc7f2d369c01da75f9d6ec4d6e8069a?context=explore) which already supports multi-platform, it seems everything is easy, just add `<buildx>` to the pom and you're done.

But still encountered unanticipated problems.

[Buildx](https://github.com/docker/buildx) uses  [QEMU](https://www.qemu.org/) to simulate other non-native platforms so that it can build images of multi-architectures on a single machine. `QEMU` is after all an emulation environment, and starting GlassFish in QEMU simulator was very slow, exceeding the default timeout of 60 seconds for the `asadmin start-domain`, causing me to always fail when building arm64 images on x86 machines, so I had to modify the timeout of `asadmin start-domain` by setting the environment variable `AS_START_TIMEOUT` :

```dockerfile
&& AS_START_TIMEOUT=120000 asadmin start-domain \
```

In the QEMU simulator, not only does GlassFish start up slowly, but it runs just as slow. After `asadmin start-domain` returns successfully, the server is not really ready, and executing other `asadmin` commands immediately afterwards will fail. A workaround is to use `curl` to access it and wait for the server to be fully ready.

```dockerfile
&& curl  -o /dev/null http://localhost:4848 \
```

I tested building and pushing  multi-architectures image on a linux/amd64 machine.

```bash
mvn clean deploy docker:push
```

The test has successfully pushed  the [multi-architecture image](https://hub.docker.com/layers/mz1999/glassfish/7.0.4/images/sha256-a0f1dea59e241bc3404c2cba38e8e310cf3c1e298ac6a02cf12f7b0b8bdd3d18?context=repo) to the docker hub.

![multi-architecture image](https://raw.githubusercontent.com/mz1999/material/master/images202304281621525.png)
