### PR TITLE
Use the startserv script as CMD by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
                 <includes>
                     <include>Dockerfile</include>
                     <include>dockerlibfile-fragment.txt</include>
+                    <include>README.md</include>
                 </includes>
                 <filtering>true</filtering>
             </resource>

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -64,4 +64,4 @@ RUN true \
 USER glassfish
 WORKDIR ${PATH_GF_HOME}
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["asadmin", "start-domain", "--verbose"]
+CMD ["startserv"]

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -1,0 +1,60 @@
+# Eclipse GlassFish Docker images (by OmniFish)
+
+**Source code repository:** https://github.com/OmniFish-EE/docker-library-glassfish
+
+## Quick start
+
+### Start GlassFish
+
+Run GlassFish with the following command:
+
+```
+docker run -p 8080:8080 -p 4848:4848 omnifish/glassfish
+```
+
+Or with a command for a specific tag (GlassFish version):
+
+```
+docker run -p 8080:8080 -p 4848:4848 omnifish/glassfish:@glassfish.version@
+```
+
+Open the following URLs in the browser:
+
+* **Welcome screen:** http://localhost:8080
+* **Administration Console:** https://localhost:4848 - log in using `admin`/`admin` (User name/Password) 
+
+### Stop GlassFish
+
+Stop GlassFish with the following command:
+
+```
+docker stop CONTAINER_ID
+```
+
+CONTAINER_ID can be found from the output of the following command:
+
+```
+docker ps
+```
+
+## Run an application with GlassFish in Docker
+
+You can run an application located in your filesystem with GlassFIsh in a Docker container.
+
+Follow these steps:
+
+1. Create an empty directory on your filesystem, e.g. `/deployment`
+2. Copy the application package to this directory - so that it's for example on the path `/deployment/application.war`
+3. Run the following command to start GlassFish in Docker with your application, where `/deployments` is path to the directory created in step 1:
+
+```
+docker run -p 8080:8080 -p 4848:4848 -v /deployments:/opt/glassfish7/glassfish/domains/domain1/autodeploy omnifish/glassfish:latest
+```
+
+Then you can open the application in the browser with:
+
+* http://localhost:9080/application
+
+The context root (`application`) is derived from the name of the application file (e.g. `application.war` would deployed under the `application` context root). If your application file has a different name, please adjust the contest root in the URL accordingly.
+
+---

--- a/src/main/resources/docker-entrypoint.sh
+++ b/src/main/resources/docker-entrypoint.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 set -e;
 
-if [ "$1" != 'asadmin' ]; then
+if [ "$1" != 'asadmin' -a "$1" != 'startserv' ]; then
     exec "$@"
+fi
+
+CONTAINER_ALREADY_STARTED="CONTAINER_ALREADY_STARTED_PLACEHOLDER"
+if [ ! -f "$CONTAINER_ALREADY_STARTED" ]
+then
+    touch "$CONTAINER_ALREADY_STARTED" &&
+    rm -rf glassfish/domains/domain1/autodeploy/.autodeploystatus || true
+fi
+
+if [ "$1" == 'startserv' ]; then
+  exec "$@"
 fi
 
 on_exit () {
@@ -13,12 +24,5 @@ on_exit () {
     exit $EXIT_CODE;
 }
 trap on_exit EXIT
-
-CONTAINER_ALREADY_STARTED="CONTAINER_ALREADY_STARTED_PLACEHOLDER"
-if [ ! -f "$CONTAINER_ALREADY_STARTED" ]
-then
-    touch "$CONTAINER_ALREADY_STARTED" &&
-    rm -rf glassfish/domains/domain1/autodeploy/.autodeploystatus || true
-fi
 
 env|sort && "$@" & wait


### PR DESCRIPTION
Use the startserv script as CMD by default.
Add README with documentation for each docker tag. 